### PR TITLE
expose swift values as public var `value`

### DIFF
--- a/Sources/ASN1Parser/Values/ASN1Boolean.swift
+++ b/Sources/ASN1Parser/Values/ASN1Boolean.swift
@@ -9,11 +9,11 @@ import Foundation
 
 /// Represents an ASN.1 Boolean value
 public struct ASN1Boolean: ASN1Value {
-  var swiftValue: Bool
+  public var value: Bool
   
   /// Construct given a swift Bool value
   public init(_ swiftValue: Bool) {
-    self.swiftValue = swiftValue
+    self.value = swiftValue
   }
 }
 
@@ -21,6 +21,6 @@ extension ASN1Boolean: Equatable {}
 
 extension ASN1Boolean: CustomStringConvertible {
   public var description: String {
-    "BOOL = \(swiftValue)"
+    "BOOL = \(value)"
   }
 }

--- a/Sources/ASN1Parser/Values/ASN1Integer.swift
+++ b/Sources/ASN1Parser/Values/ASN1Integer.swift
@@ -10,16 +10,16 @@ import BigInt
 
 /// Represents an ASN.1 Integer value
 public struct ASN1Integer: ASN1Value {
-  var swiftValue: BigInt
+  public var value: BigInt
   
   /// Construct given a swift Int value
-  public init (_ swiftValue: Int) {
-    self.swiftValue = BigInt(swiftValue)
+  public init (_ value: Int) {
+    self.value = BigInt(value)
   }
   
   /// Construct given an arbitray length Integer
-  public init(_ swiftValue: BigInt) {
-    self.swiftValue = swiftValue
+  public init(_ value: BigInt) {
+    self.value = value
   }
 }
 
@@ -27,6 +27,6 @@ extension ASN1Integer: Equatable {}
 
 extension ASN1Integer: CustomStringConvertible {
   public var description: String {
-    "INTEGER = \(swiftValue)"
+    "INTEGER = \(value)"
   }
 }

--- a/Sources/ASN1Parser/Values/ASN1ObjectIdentifier.swift
+++ b/Sources/ASN1Parser/Values/ASN1ObjectIdentifier.swift
@@ -14,7 +14,7 @@ public struct ASN1ObjectIdentifier: ASN1Value {
   public var nodes = [BigUInt]()
   
   /// Canonical string representation, separating nodes by a single '.' each
-  public var id: String {
+  public var value: String {
     nodes.map {
       "\($0)"
     }.joined(separator: ".")
@@ -59,6 +59,6 @@ extension ASN1ObjectIdentifier: Equatable {}
 
 extension ASN1ObjectIdentifier: CustomStringConvertible {
   public var description: String {
-    "OBJECT IDENTIFIER = \(id)"
+    "OBJECT IDENTIFIER = \(value)"
   }
 }

--- a/Sources/ASN1Parser/Values/ASN1Set.swift
+++ b/Sources/ASN1Parser/Values/ASN1Set.swift
@@ -56,7 +56,7 @@ public struct ASN1Set: ASN1Value {
   }
   
   /// Returns all values of the set in any order
-  public var all: [ASN1Value] {
+  public var values: [ASN1Value] {
     [first] + remaining
   }
 }
@@ -67,8 +67,8 @@ extension ASN1Set: Equatable {
     guard lhs.count == rhs.count else { return false }
     
     // check must be more complicated since order is technically irrelevant
-    var otherVals = rhs.all
-    return lhs.all.allSatisfy { val in
+    var otherVals = rhs.values
+    return lhs.values.allSatisfy { val in
       guard let ind = otherVals.firstIndex(where: { val.isEqualTo($0) }) else { return false }
       otherVals.remove(at: ind)
       return true
@@ -78,6 +78,6 @@ extension ASN1Set: Equatable {
 
 extension ASN1Set: CustomStringConvertible {
   public var description: String {
-    "SET:\n" + all.map { "\t\($0)".replacingOccurrences(of: "\n", with: "\n\t") }.joined(separator: "\n")
+    "SET:\n" + values.map { "\t\($0)".replacingOccurrences(of: "\n", with: "\n\t") }.joined(separator: "\n")
   }
 }

--- a/Sources/ASN1Parser/Values/DER/ASN1Boolean+DER.swift
+++ b/Sources/ASN1Parser/Values/DER/ASN1Boolean+DER.swift
@@ -19,6 +19,6 @@ extension ASN1Boolean: DERDecodable {
       throw ASN1ValueParsingError.invalidBoolean
     }
     
-    swiftValue = byte != 0
+    value = byte != 0
   }
 }

--- a/Sources/ASN1Parser/Values/DER/ASN1Integer+DER.swift
+++ b/Sources/ASN1Parser/Values/DER/ASN1Integer+DER.swift
@@ -26,9 +26,9 @@ extension ASN1Integer: DERDecodable {
       var bytes = [UInt8](dataView)
       bytes[0] &= (0x1 << 7) - 1
       
-      swiftValue = BigInt(sign: .minus, magnitude: BigUInt(Data(bytes)))
+      value = BigInt(sign: .minus, magnitude: BigUInt(Data(bytes)))
     } else {
-      swiftValue = BigInt(sign: .plus, magnitude: BigUInt(dataView))
+      value = BigInt(sign: .plus, magnitude: BigUInt(dataView))
     }
   }
 }

--- a/Tests/ASN1ParserTests/ConstructValueTests.swift
+++ b/Tests/ASN1ParserTests/ConstructValueTests.swift
@@ -7,18 +7,18 @@ import BigInt
 final class ConstructValueTests: XCTestCase {
   func testConstructBoolean() throws {
     let bool = ASN1Boolean(true)
-    XCTAssertEqual(bool.swiftValue, true)
+    XCTAssertEqual(bool.value, true)
     
     let bool2 = ASN1Boolean(false)
-    XCTAssertEqual(bool2.swiftValue, false)
+    XCTAssertEqual(bool2.value, false)
   }
   
   func testConstructInteger() throws {
     let int = ASN1Integer(1337)
-    XCTAssertEqual(int.swiftValue, 1337)
+    XCTAssertEqual(int.value, 1337)
     
     let int2 = ASN1Integer(-50)
-    XCTAssertEqual(int2.swiftValue, -50)
+    XCTAssertEqual(int2.value, -50)
     
     let longUIntData = Data([
       0x8f, 0xe2, 0x41, 0x2a, 0x08, 0xe8, 0x51, 0xa8,
@@ -39,7 +39,7 @@ final class ConstructValueTests: XCTestCase {
       0x3a, 0x37, 0x42, 0x45, 0x75, 0xdc, 0x90, 0x65
     ])
     let int3 = ASN1Integer(BigInt(longUIntData))
-    XCTAssertEqual(int3.swiftValue, BigInt(longUIntData))
+    XCTAssertEqual(int3.value, BigInt(longUIntData))
   }
   
   func testConstructNull() throws {
@@ -113,7 +113,7 @@ final class ConstructValueTests: XCTestCase {
     XCTAssertEqual(seq.values.count, 1)
     XCTAssert(seq.values.first is ASN1Boolean)
     if let bool = seq.values.first as? ASN1Boolean {
-      XCTAssertEqual(bool.swiftValue, false)
+      XCTAssertEqual(bool.value, false)
     }
     
     let seq2 = try ASN1Sequence([ASN1Boolean(false)])
@@ -139,7 +139,7 @@ final class ConstructValueTests: XCTestCase {
     XCTAssertEqual(set.count, 1)
     XCTAssert(set.any is ASN1Boolean)
     if let bool = set.any as? ASN1Boolean {
-      XCTAssertEqual(bool.swiftValue, false)
+      XCTAssertEqual(bool.value, false)
     }
     
     let set2 = try ASN1Set([ASN1Boolean(false)])
@@ -147,7 +147,7 @@ final class ConstructValueTests: XCTestCase {
     
     let set3 = ASN1Set(ASN1Boolean(true), ASN1Boolean(false), ASN1Boolean(false))
     XCTAssertEqual(set3.count, 3)
-    set3.all.forEach { val in
+    set3.values.forEach { val in
       XCTAssert(val is ASN1Boolean)
     }
     

--- a/Tests/ASN1ParserTests/ParseValueTests.swift
+++ b/Tests/ASN1ParserTests/ParseValueTests.swift
@@ -34,14 +34,14 @@ final class ParseValueTests: XCTestCase {
     var val: ASN1Value = try DERParser.parse(der: Data([DERParser.Tag.boolean.rawValue, 0x01, 0x00]))
     XCTAssert(val is ASN1Boolean)
     if let bool = val as? ASN1Boolean {
-      XCTAssertEqual(bool.swiftValue, false)
+      XCTAssertEqual(bool.value, false)
     }
     
     // true value
     val = try DERParser.parse(der: Data([DERParser.Tag.boolean.rawValue, 0x01, 0x01]))
     XCTAssert(val is ASN1Boolean)
     if let bool = val as? ASN1Boolean {
-      XCTAssertEqual(bool.swiftValue, true)
+      XCTAssertEqual(bool.value, true)
     }
     
     // failed parsing wrong bool values
@@ -57,13 +57,13 @@ final class ParseValueTests: XCTestCase {
     var val: ASN1Value = try DERParser.parse(der: Data([DERParser.Tag.integer.rawValue, 0x01, 0x03]))
     XCTAssert(val is ASN1Integer)
     if let int = val as? ASN1Integer {
-      XCTAssertEqual(int.swiftValue, 3)
+      XCTAssertEqual(int.value, 3)
     }
 
     val = try DERParser.parse(der: Data([DERParser.Tag.integer.rawValue, 0x01, 0x85]))
     XCTAssert(val is ASN1Integer)
     if let int = val as? ASN1Integer {
-      XCTAssertEqual(int.swiftValue, -5)
+      XCTAssertEqual(int.value, -5)
     }
     
     let longUIntData: [UInt8] = [
@@ -89,7 +89,7 @@ final class ParseValueTests: XCTestCase {
     XCTAssert(val is ASN1Integer)
     if let int = val as? ASN1Integer {
       let referenceVal = BigInt(sign: .plus, magnitude: BigUInt(Data(longUIntData)))
-      XCTAssertEqual(referenceVal, int.swiftValue)
+      XCTAssertEqual(referenceVal, int.value)
     }
   }
   
@@ -105,19 +105,19 @@ final class ParseValueTests: XCTestCase {
     var val: ASN1Value = try DERParser.parse(der: Data([DERParser.Tag.objectIdentifier.rawValue, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01]))
     XCTAssert(val is ASN1ObjectIdentifier)
     if let objectID = val as? ASN1ObjectIdentifier {
-      XCTAssertEqual(objectID.id, "1.2.840.10045.2.1")
+      XCTAssertEqual(objectID.value, "1.2.840.10045.2.1")
     }
     
     val = try DERParser.parse(der: Data([DERParser.Tag.objectIdentifier.rawValue, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07]))
     XCTAssert(val is ASN1ObjectIdentifier)
     if let objectID = val as? ASN1ObjectIdentifier {
-      XCTAssertEqual(objectID.id, "1.2.840.10045.3.1.7")
+      XCTAssertEqual(objectID.value, "1.2.840.10045.3.1.7")
     }
     
     val = try DERParser.parse(der: Data([DERParser.Tag.objectIdentifier.rawValue, 0x09, 0x2b, 0x06, 0x01, 0x04, 0x01, 0x82, 0x37, 0x15, 0x14]))
     XCTAssert(val is ASN1ObjectIdentifier)
     if let objectID = val as? ASN1ObjectIdentifier {
-      XCTAssertEqual(objectID.id, "1.3.6.1.4.1.311.21.20")
+      XCTAssertEqual(objectID.value, "1.3.6.1.4.1.311.21.20")
     }
     
     
@@ -204,7 +204,7 @@ final class ParseValueTests: XCTestCase {
       XCTAssertEqual(sequence.values.count, 1)
       XCTAssert(sequence.values.first is ASN1Boolean)
       if let bool = sequence.values.first as? ASN1Boolean {
-        XCTAssertEqual(bool.swiftValue, true)
+        XCTAssertEqual(bool.value, true)
       }
     }
     
@@ -221,7 +221,7 @@ final class ParseValueTests: XCTestCase {
       zip(sequence.values, [false, true, false]).forEach { bool, expected in
         XCTAssert(bool is ASN1Boolean)
         if let bool = bool as? ASN1Boolean {
-          XCTAssertEqual(bool.swiftValue, expected)
+          XCTAssertEqual(bool.value, expected)
         }
       }
     }
@@ -241,7 +241,7 @@ final class ParseValueTests: XCTestCase {
       XCTAssertEqual(set.count, 1)
       XCTAssert(set.any is ASN1Boolean)
       if let bool = set.any as? ASN1Boolean {
-        XCTAssertEqual(bool.swiftValue, true)
+        XCTAssertEqual(bool.value, true)
       }
     }
     
@@ -258,11 +258,11 @@ final class ParseValueTests: XCTestCase {
       
       var falseCnt = 0
       var trueCnt = 0
-      set.all.forEach { bool in
+      set.values.forEach { bool in
         XCTAssert(bool is ASN1Boolean)
         if let bool = bool as? ASN1Boolean {
-          falseCnt += bool.swiftValue == false ? 1 : 0
-          trueCnt += bool.swiftValue == true ? 1 : 0
+          falseCnt += bool.value == false ? 1 : 0
+          trueCnt += bool.value == true ? 1 : 0
         }
       }
       XCTAssert(trueCnt == 1)


### PR DESCRIPTION
Some Types like ASN1Integer did not expose their underlying swift value outside of the API boundary as pointed out in #1 

This PR aims to solve this issue.