### PR TITLE
Fixed length calculation to successfully parse keys of certificates and added printable string

### DIFF
--- a/Sources/ASN1Parser/DERParser+TLV.swift
+++ b/Sources/ASN1Parser/DERParser+TLV.swift
@@ -1,6 +1,6 @@
 //
 //  DERParser+TLV.swift
-//  
+//
 //
 //  Created by Dominik Horn on 10.11.21.
 //
@@ -9,87 +9,96 @@ import Foundation
 import BigInt
 
 extension DERParser {
-  /// As documented in https://docs.microsoft.com/en-us/windows/win32/seccertenroll/about-encoded-length-and-value-bytes
-  struct Length {
-    var value: Int
-    
-    init(_ der: Data, offset: inout Data.Index) throws {
-      let firstByte = try der.tryAccess(at: offset)
-      offset += 1
-      
-      value = Int(firstByte)
-      
-      if firstByte.bit(at: 7) {
-        let trailingByteCount = Int(firstByte & ((0x1 << 7) - 1))
+    /// As documented in https://docs.microsoft.com/en-us/windows/win32/seccertenroll/about-encoded-length-and-value-bytes
+    struct Length {
+        var value: Int
         
-        guard trailingByteCount > 0 && trailingByteCount < MemoryLayout<Int>.size else {
-          throw ASN1DERParsingError.unsupportedTLVLength
+        init(_ der: Data, offset: inout Data.Index) throws {
+            let firstByte = try der.tryAccess(at: offset)
+            offset += 1
+            
+            value = Int(firstByte)
+            
+            if firstByte.bit(at: 7) {
+                let trailingByteCount = Int(firstByte & ((0x1 << 7) - 1))
+                
+                guard trailingByteCount > 0 && trailingByteCount < MemoryLayout<Int>.size else {
+                    throw ASN1DERParsingError.unsupportedTLVLength
+                }
+                var lengthBytes: [UInt8] = Array(repeating: 0, count: trailingByteCount)
+                
+                let dataView = der[offset..<(offset+trailingByteCount)]
+                offset += trailingByteCount
+                (dataView as NSData).getBytes(&lengthBytes, length: MemoryLayout<Int>.size)
+                
+                value = Int(lengthBytes[0]) // initial byte will then be shifted for all following bytes
+                for i in 1..<lengthBytes.count { // start index will be 1 (the second byte)
+                    value = value << 8 | Int(lengthBytes[i])
+                }
+            }
         }
-
-        let dataView = der[offset..<(offset+trailingByteCount)]
-        offset += trailingByteCount
-        (dataView as NSData).getBytes(&value, length: MemoryLayout<Int>.size)
-      }
-    }
-  }
-  
-  /// As documented in https://docs.microsoft.com/en-us/windows/win32/seccertenroll/about-encoded-tag-bytes
-  enum Tag: UInt8 {
-    case boolean = 0x01
-    case integer = 0x02
-    case bitString = 0x03
-    case octetString = 0x04
-    case null = 0x05
-    case objectIdentifier = 0x06
-    case utf8String = 0x0C
-    case sequence = 0x30
-    case set = 0x31
-    
-    init(_ der: Data, offset: inout Data.Index) throws {
-      let firstByte = try der.tryAccess(at: offset)
-      guard let tag = Tag(rawValue: firstByte) else {
-        throw ASN1DERParsingError.unreadableTag(firstByte)
-      }
-      self = tag
-      offset += 1
-    }
-  }
-  
-  internal static func parseTLV(_ der: Data, offset: inout Data.Index) throws -> ASN1Value {
-    let tag = try Tag(der, offset: &offset)
-    let length = try Length(der, offset: &offset)
-    
-    // perform bounds check before access
-    guard length.value <= der.endIndex - offset else {
-      throw ASN1DERParsingError.invalidTLVLength
     }
     
-    // each tag identifies a specific ASN1Value
-    var value: ASN1Value
-    let derView = length.value > 0 ? der[offset..<(offset+length.value)] : .init()
-    
-    switch tag {
-    case .null:
-      value = try ASN1Null(der: derView)
-    case .boolean:
-      value = try ASN1Boolean(der: derView)
-    case .integer:
-      value = try ASN1Integer(der: derView)
-    case .objectIdentifier:
-      value = try ASN1ObjectIdentifier(der: derView)
-    case .bitString:
-      value = try ASN1BitString(der: derView)
-    case .octetString:
-      value = try ASN1OctetString(der: derView)
-    case .utf8String:
-      value = try ASN1UTF8String(der: derView)
-    case .sequence:
-      value = try ASN1Sequence(der: derView)
-    case .set:
-      value = try ASN1Set(der: derView)
+    /// As documented in https://docs.microsoft.com/en-us/windows/win32/seccertenroll/about-encoded-tag-bytes
+    enum Tag: UInt8 {
+        case boolean = 0x01
+        case integer = 0x02
+        case bitString = 0x03
+        case octetString = 0x04
+        case null = 0x05
+        case objectIdentifier = 0x06
+        case utf8String = 0x0C
+        case printableString = 0x13
+        case sequence = 0x30
+        case set = 0x31
+        
+        init(_ der: Data, offset: inout Data.Index) throws {
+            let firstByte = try der.tryAccess(at: offset)
+            guard let tag = Tag(rawValue: firstByte) else {
+                throw ASN1DERParsingError.unreadableTag(firstByte)
+            }
+            self = tag
+            offset += 1
+        }
     }
     
-    offset += length.value
-    return value
-  }
+    internal static func parseTLV(_ der: Data, offset: inout Data.Index) throws -> ASN1Value {
+        let tag = try Tag(der, offset: &offset)
+        let length = try Length(der, offset: &offset)
+        
+        // perform bounds check before access
+        guard length.value <= der.endIndex - offset else {
+            throw ASN1DERParsingError.invalidTLVLength
+        }
+        
+        // each tag identifies a specific ASN1Value
+        var value: ASN1Value
+        let derView = length.value > 0 ? der[offset..<(offset+length.value)] : .init()
+        
+        switch tag {
+        case .null:
+            value = try ASN1Null(der: derView)
+        case .boolean:
+            value = try ASN1Boolean(der: derView)
+        case .integer:
+            value = try ASN1Integer(der: derView)
+        case .objectIdentifier:
+            value = try ASN1ObjectIdentifier(der: derView)
+        case .bitString:
+            value = try ASN1BitString(der: derView)
+        case .octetString:
+            value = try ASN1OctetString(der: derView)
+        case .printableString:
+            value = try ASN1PrintableString(der: derView)
+        case .utf8String:
+            value = try ASN1UTF8String(der: derView)
+        case .sequence:
+            value = try ASN1Sequence(der: derView)
+        case .set:
+            value = try ASN1Set(der: derView)
+        }
+        
+        offset += length.value
+        return value
+    }
 }

--- a/Sources/ASN1Parser/Values/ASN1Boolean.swift
+++ b/Sources/ASN1Parser/Values/ASN1Boolean.swift
@@ -9,11 +9,11 @@ import Foundation
 
 /// Represents an ASN.1 Boolean value
 public struct ASN1Boolean: ASN1Value {
-  var swiftValue: Bool
+  public var value: Bool
   
   /// Construct given a swift Bool value
   public init(_ swiftValue: Bool) {
-    self.swiftValue = swiftValue
+    self.value = swiftValue
   }
 }
 
@@ -21,6 +21,6 @@ extension ASN1Boolean: Equatable {}
 
 extension ASN1Boolean: CustomStringConvertible {
   public var description: String {
-    "BOOL = \(swiftValue)"
+    "BOOL = \(value)"
   }
 }

--- a/Sources/ASN1Parser/Values/ASN1Integer.swift
+++ b/Sources/ASN1Parser/Values/ASN1Integer.swift
@@ -10,16 +10,16 @@ import BigInt
 
 /// Represents an ASN.1 Integer value
 public struct ASN1Integer: ASN1Value {
-  var swiftValue: BigInt
+  public var value: BigInt
   
   /// Construct given a swift Int value
-  public init (_ swiftValue: Int) {
-    self.swiftValue = BigInt(swiftValue)
+  public init (_ value: Int) {
+    self.value = BigInt(value)
   }
   
   /// Construct given an arbitray length Integer
-  public init(_ swiftValue: BigInt) {
-    self.swiftValue = swiftValue
+  public init(_ value: BigInt) {
+    self.value = value
   }
 }
 
@@ -27,6 +27,6 @@ extension ASN1Integer: Equatable {}
 
 extension ASN1Integer: CustomStringConvertible {
   public var description: String {
-    "INTEGER = \(swiftValue)"
+    "INTEGER = \(value)"
   }
 }

--- a/Sources/ASN1Parser/Values/ASN1ObjectIdentifier.swift
+++ b/Sources/ASN1Parser/Values/ASN1ObjectIdentifier.swift
@@ -14,7 +14,7 @@ public struct ASN1ObjectIdentifier: ASN1Value {
   public var nodes = [BigUInt]()
   
   /// Canonical string representation, separating nodes by a single '.' each
-  public var id: String {
+  public var value: String {
     nodes.map {
       "\($0)"
     }.joined(separator: ".")
@@ -59,6 +59,6 @@ extension ASN1ObjectIdentifier: Equatable {}
 
 extension ASN1ObjectIdentifier: CustomStringConvertible {
   public var description: String {
-    "OBJECT IDENTIFIER = \(id)"
+    "OBJECT IDENTIFIER = \(value)"
   }
 }

--- a/Sources/ASN1Parser/Values/ASN1PrintableString.swift
+++ b/Sources/ASN1Parser/Values/ASN1PrintableString.swift
@@ -1,0 +1,27 @@
+//
+//  ASN1PrintableString.swift
+//  
+//
+//  Created by Matthias Scheurer on 29.09.23.
+//
+
+import Foundation
+
+/// Represents an ASN.1 UTF-8 String value
+public struct ASN1PrintableString: ASN1Value {
+  /// Decoded string value
+  public var value: String
+  
+  /// Construct given a swift String value
+  public init(_ value: String) {
+    self.value = value
+  }
+}
+
+extension ASN1PrintableString: Equatable {}
+
+extension ASN1PrintableString: CustomStringConvertible {
+  public var description: String {
+    "PRINTABLE STRING = \(value)"
+  }
+}

--- a/Sources/ASN1Parser/Values/ASN1Set.swift
+++ b/Sources/ASN1Parser/Values/ASN1Set.swift
@@ -56,7 +56,7 @@ public struct ASN1Set: ASN1Value {
   }
   
   /// Returns all values of the set in any order
-  public var all: [ASN1Value] {
+  public var values: [ASN1Value] {
     [first] + remaining
   }
 }
@@ -67,8 +67,8 @@ extension ASN1Set: Equatable {
     guard lhs.count == rhs.count else { return false }
     
     // check must be more complicated since order is technically irrelevant
-    var otherVals = rhs.all
-    return lhs.all.allSatisfy { val in
+    var otherVals = rhs.values
+    return lhs.values.allSatisfy { val in
       guard let ind = otherVals.firstIndex(where: { val.isEqualTo($0) }) else { return false }
       otherVals.remove(at: ind)
       return true
@@ -78,6 +78,6 @@ extension ASN1Set: Equatable {
 
 extension ASN1Set: CustomStringConvertible {
   public var description: String {
-    "SET:\n" + all.map { "\t\($0)".replacingOccurrences(of: "\n", with: "\n\t") }.joined(separator: "\n")
+    "SET:\n" + values.map { "\t\($0)".replacingOccurrences(of: "\n", with: "\n\t") }.joined(separator: "\n")
   }
 }

--- a/Sources/ASN1Parser/Values/ASN1Value+convenientAccess.swift
+++ b/Sources/ASN1Parser/Values/ASN1Value+convenientAccess.swift
@@ -49,6 +49,11 @@ public extension ASN1Value {
   var asUTF8String: ASN1UTF8String {
     get throws { try cast(self) }
   }
+    
+  /// Try casting to ``ASN1UTF8String`` Throws if cast fails
+  var asPrintableString: ASN1PrintableString {
+    get throws { try cast(self) }
+  }
   
   /// Try casting to ``ASN1Sequence`` Throws if cast fails
   var asSequence: ASN1Sequence {

--- a/Sources/ASN1Parser/Values/DER/ASN1Boolean+DER.swift
+++ b/Sources/ASN1Parser/Values/DER/ASN1Boolean+DER.swift
@@ -19,6 +19,6 @@ extension ASN1Boolean: DERDecodable {
       throw ASN1ValueParsingError.invalidBoolean
     }
     
-    swiftValue = byte != 0
+    value = byte != 0
   }
 }

--- a/Sources/ASN1Parser/Values/DER/ASN1Integer+DER.swift
+++ b/Sources/ASN1Parser/Values/DER/ASN1Integer+DER.swift
@@ -26,9 +26,9 @@ extension ASN1Integer: DERDecodable {
       var bytes = [UInt8](dataView)
       bytes[0] &= (0x1 << 7) - 1
       
-      swiftValue = BigInt(sign: .minus, magnitude: BigUInt(Data(bytes)))
+      value = BigInt(sign: .minus, magnitude: BigUInt(Data(bytes)))
     } else {
-      swiftValue = BigInt(sign: .plus, magnitude: BigUInt(dataView))
+      value = BigInt(sign: .plus, magnitude: BigUInt(dataView))
     }
   }
 }

--- a/Sources/ASN1Parser/Values/DER/ASN1PrintableString+DER.swift
+++ b/Sources/ASN1Parser/Values/DER/ASN1PrintableString+DER.swift
@@ -1,0 +1,15 @@
+//
+//  ASN1PrintableString+DER.swift
+//  
+//
+//  Created by Matthias Scheurer on 29.09.23.
+//
+
+import Foundation
+
+extension ASN1PrintableString: DERDecodable {
+  /// https://docs.microsoft.com/en-us/windows/win32/seccertenroll/about-utf8string
+  init(der: Data) throws {
+      self.value = .init(decoding: der, as: UTF8.self)
+  }
+}

--- a/Tests/ASN1ParserTests/ConstructValueTests.swift
+++ b/Tests/ASN1ParserTests/ConstructValueTests.swift
@@ -7,18 +7,18 @@ import BigInt
 final class ConstructValueTests: XCTestCase {
   func testConstructBoolean() throws {
     let bool = ASN1Boolean(true)
-    XCTAssertEqual(bool.swiftValue, true)
+    XCTAssertEqual(bool.value, true)
     
     let bool2 = ASN1Boolean(false)
-    XCTAssertEqual(bool2.swiftValue, false)
+    XCTAssertEqual(bool2.value, false)
   }
   
   func testConstructInteger() throws {
     let int = ASN1Integer(1337)
-    XCTAssertEqual(int.swiftValue, 1337)
+    XCTAssertEqual(int.value, 1337)
     
     let int2 = ASN1Integer(-50)
-    XCTAssertEqual(int2.swiftValue, -50)
+    XCTAssertEqual(int2.value, -50)
     
     let longUIntData = Data([
       0x8f, 0xe2, 0x41, 0x2a, 0x08, 0xe8, 0x51, 0xa8,
@@ -39,7 +39,7 @@ final class ConstructValueTests: XCTestCase {
       0x3a, 0x37, 0x42, 0x45, 0x75, 0xdc, 0x90, 0x65
     ])
     let int3 = ASN1Integer(BigInt(longUIntData))
-    XCTAssertEqual(int3.swiftValue, BigInt(longUIntData))
+    XCTAssertEqual(int3.value, BigInt(longUIntData))
   }
   
   func testConstructNull() throws {
@@ -113,7 +113,7 @@ final class ConstructValueTests: XCTestCase {
     XCTAssertEqual(seq.values.count, 1)
     XCTAssert(seq.values.first is ASN1Boolean)
     if let bool = seq.values.first as? ASN1Boolean {
-      XCTAssertEqual(bool.swiftValue, false)
+      XCTAssertEqual(bool.value, false)
     }
     
     let seq2 = try ASN1Sequence([ASN1Boolean(false)])
@@ -139,7 +139,7 @@ final class ConstructValueTests: XCTestCase {
     XCTAssertEqual(set.count, 1)
     XCTAssert(set.any is ASN1Boolean)
     if let bool = set.any as? ASN1Boolean {
-      XCTAssertEqual(bool.swiftValue, false)
+      XCTAssertEqual(bool.value, false)
     }
     
     let set2 = try ASN1Set([ASN1Boolean(false)])
@@ -147,7 +147,7 @@ final class ConstructValueTests: XCTestCase {
     
     let set3 = ASN1Set(ASN1Boolean(true), ASN1Boolean(false), ASN1Boolean(false))
     XCTAssertEqual(set3.count, 3)
-    set3.all.forEach { val in
+    set3.values.forEach { val in
       XCTAssert(val is ASN1Boolean)
     }
     

--- a/Tests/ASN1ParserTests/ParseCertificateTests.swift
+++ b/Tests/ASN1ParserTests/ParseCertificateTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import ASN1Parser
+
+import BigInt
+
+func createCert() -> SecCertificate? {
+    let str = """
+    -----BEGIN CERTIFICATE-----
+    MIIGuTCCBKGgAwIBAgIQAv4qsyJpAcAUg4A9KMzh8jANBgkqhkiG9w0BAQwFADBN
+    MQswCQYDVQQGEwJVUzEXMBUGA1UEChMORGlnaUNlcnQsIEluYy4xJTAjBgNVBAMT
+    HERpZ2lDZXJ0IFRMUyBSU0E0MDk2IFJvb3QgRzUwHhcNMjIwNTI2MDAwMDAwWhcN
+    MzIwNTI1MjM1OTU5WjBWMQswCQYDVQQGEwJVUzEXMBUGA1UEChMORGlnaUNlcnQs
+    IEluYy4xLjAsBgNVBAMTJVRoYXd0ZSBHNSBUTFMgUlNBNDA5NiBTSEEzODQgMjAy
+    MiBDQTEwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCxmeAZITkz2kwO
+    Cv3is/gHClg+Gg/+t9X6jhYR82bzdKqyv4Q4MS5z2jUGmPaXzEIhOv41lt5S59Qw
+    HuURjQy/V12ycNQwUnLhMXfGhbJ62tnBX9ezRO5SdpBvpjDI4CFiLnl5V+lhPA+z
+    u3Qy4CisAAllIQtmiZ9rGqHG3qwi9UhgAHvzEDMH44Bax2VvvgA+mpgV5NWomvbI
+    66k7w3635iClqGsmtEFd1pqRK2lrDa/KNcu9KomQt7iuSDZA+Tl4uu8hf0F9NAya
+    rr7XEHAkFxwiDK/9n7HfwVVBBlri1OhvU4DPFE7E4rBpuOXPk7L4RPwSiJMa1qIz
+    5prmLIRLxuMrG3M5IqQ+W9ptYhvQLzBTvUIIzjy62GfvJ5Kq0t1AvlmKOlprsSCW
+    6R5bG+yCvrIdsDcvcxJgU9ZKvtHxmC3TGhckybUyFQeLgd01cXrkJGRP0dcGzIYv
+    37jW82dr4O1OvJbZnl8/b6cxIIul2fTxS0djgoW3ow7hvFu/0ZNUM5o4THMaBt6R
+    I8e1F2x3XJqEwJrQegS3JYijmihgC5B/tqgwKZmXS0u42e9oMQH0yvUUBgHtVewh
+    7CGAnoTlKiODy6Z8Q0TUc/dsGGD9E8h/Ecia1feKVN3okB/VOZBlOaMB4uNSBp0h
+    W8XuX+5DPu+Q2P7xowU7d+YvOfj0aQIDAQABo4IBijCCAYYwEgYDVR0TAQH/BAgw
+    BgEB/wIBADAdBgNVHQ4EFgQUTedvYaz6SwI1b6hXPOFOoEU8DmcwHwYDVR0jBBgw
+    FoAUUTMc7TZArxfTJc1paPKvTiM+s0EwDgYDVR0PAQH/BAQDAgGGMB0GA1UdJQQW
+    MBQGCCsGAQUFBwMBBggrBgEFBQcDAjB6BggrBgEFBQcBAQRuMGwwJAYIKwYBBQUH
+    MAGGGGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0LmNvbTBEBggrBgEFBQcwAoY4aHR0cDov
+    L2NhY2VydHMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0VExTUlNBNDA5NlJvb3RHNS5j
+    cnQwRgYDVR0fBD8wPTA7oDmgN4Y1aHR0cDovL2NybDMuZGlnaWNlcnQuY29tL0Rp
+    Z2lDZXJ0VExTUlNBNDA5NlJvb3RHNS5jcmwwPQYDVR0gBDYwNDALBglghkgBhv1s
+    AgEwBwYFZ4EMAQEwCAYGZ4EMAQIBMAgGBmeBDAECAjAIBgZngQwBAgMwDQYJKoZI
+    hvcNAQEMBQADggIBAJf6PrJL7qiaZMBzTjmxEHA/9so1c3NtkaPAj8Toch+wvTLQ
+    AZiAAvwghHLeWsEWAzDUy1B49RT1dsvAhjN11+x6G++enasPPoLRGuPYMbUHkFzd
+    bodY5Dk4VZeYi59xmaGHLi018RlcZ8sOaHan04YDBWWdfARo+lFtyiVNrZFiRYCw
+    ScWIon5sWfNskdGQ/mk/H3cv3zubEx1vHpRSO+y2l6Sxd0Au8XTyrQDCfBQp8GKl
+    GQKISsRDbqFwAVNsFGOGFJ26DoHRNTTyuVnaLkGs39BywBi+sT1hsdCQFIC3bvjl
+    u2vsdhJoXYtxDDCKvgrRd8Ny7ovJv2MHbvf8SWc6uRwtrl0uR6SNQ3bPy+SxXlnK
+    /w4VO2267GuRcmwCgkOwK6aWbp6/OEZ2xJg1pKKORLvKvaUDhb8Mk3bYwF82dtcq
+    zRpn1Nk6oCJYUXI3eTAOyfStX70gpm17nE6l0yM/oANqVPxeCXe1/iW0SyjNGLtD
+    DcRvprkh7xONHXG7dCUlUoqjnvVxxV9isbbRiA3z2BVHckb4thxzd5tK8ntdkSyC
+    efO5mbV6kofpFMJgXCsfs1CilJrfSdPHMTx407z9id0N2L6dcroY77eqE8jylZad
+    ktJ5nIuziadSasnep+ltgHbQSU1JTFUah1RT/E9ke9rFy1sfFeXpdLLmT7a7
+    -----END CERTIFICATE-----
+    """
+    
+    // cleanup string to get plain base64 coded data
+    var pemWithoutHeaderFooterNewlines = str.replacingOccurrences(of: "-----BEGIN CERTIFICATE-----", with: "")
+    pemWithoutHeaderFooterNewlines = pemWithoutHeaderFooterNewlines.replacingOccurrences(of: "-----END CERTIFICATE-----", with: "")
+    pemWithoutHeaderFooterNewlines = pemWithoutHeaderFooterNewlines.replacingOccurrences(of: "\n", with: "")
+    pemWithoutHeaderFooterNewlines = pemWithoutHeaderFooterNewlines.replacingOccurrences(of: "\r", with: "")
+    pemWithoutHeaderFooterNewlines = pemWithoutHeaderFooterNewlines.replacingOccurrences(of: " ", with: "")
+    
+    let data = Data(base64Encoded: pemWithoutHeaderFooterNewlines)!
+    // finally create the certificate (SecCertificate)
+    return SecCertificateCreateWithData(nil, data as CFData)
+}
+
+/// Parsing values from certificate
+final class ParseCertificateTests: XCTestCase {
+    
+    var cert: SecCertificate?
+    
+    override func setUp() {
+        // XCTest calls it before calling the first test method.
+        // Set up any overall initial state here.
+        self.cert = createCert()
+    }
+    
+    func testParseCertificateIssuerSequence() throws {
+        // get the issuer sequence
+        let issuerSequenceData = SecCertificateCopyNormalizedIssuerSequence(cert!) as Data?
+                
+        let tree = try DERParser.parse(der: issuerSequenceData!)
+        print(tree)
+     
+        // Access values within the tree
+        let sequence1 = try tree.asSequence[0]
+        
+        let set1 = try sequence1.asSet.first
+        XCTAssertEqual(try set1.asSequence[0].asObjectIdentifier, try ASN1ObjectIdentifier(oid: "2.5.4.6"))
+        XCTAssertEqual(try set1.asSequence[1].asPrintableString, ASN1PrintableString("US"))
+        
+        let sequence2 = try tree.asSequence[1]
+        let set2 = try sequence2.asSet.first
+        XCTAssertEqual(try set2.asSequence[0].asObjectIdentifier, try ASN1ObjectIdentifier(oid: "2.5.4.10"))
+        XCTAssertEqual(try set2.asSequence[1].asPrintableString, ASN1PrintableString("DIGICERT, INC."))
+    }
+    
+    func testParseCertificateKey() throws {
+        // get the key and parse
+        var error: Unmanaged<CFError>?
+        if let key = SecCertificateCopyKey(cert!),
+           let keyData = SecKeyCopyExternalRepresentation(key, &error) as Data? {
+            XCTAssertNoThrow(try DERParser.parse(der: keyData))
+        }
+    }
+}

--- a/Tests/ASN1ParserTests/ParseValueTests.swift
+++ b/Tests/ASN1ParserTests/ParseValueTests.swift
@@ -34,14 +34,14 @@ final class ParseValueTests: XCTestCase {
     var val: ASN1Value = try DERParser.parse(der: Data([DERParser.Tag.boolean.rawValue, 0x01, 0x00]))
     XCTAssert(val is ASN1Boolean)
     if let bool = val as? ASN1Boolean {
-      XCTAssertEqual(bool.swiftValue, false)
+      XCTAssertEqual(bool.value, false)
     }
     
     // true value
     val = try DERParser.parse(der: Data([DERParser.Tag.boolean.rawValue, 0x01, 0x01]))
     XCTAssert(val is ASN1Boolean)
     if let bool = val as? ASN1Boolean {
-      XCTAssertEqual(bool.swiftValue, true)
+      XCTAssertEqual(bool.value, true)
     }
     
     // failed parsing wrong bool values
@@ -57,13 +57,13 @@ final class ParseValueTests: XCTestCase {
     var val: ASN1Value = try DERParser.parse(der: Data([DERParser.Tag.integer.rawValue, 0x01, 0x03]))
     XCTAssert(val is ASN1Integer)
     if let int = val as? ASN1Integer {
-      XCTAssertEqual(int.swiftValue, 3)
+      XCTAssertEqual(int.value, 3)
     }
 
     val = try DERParser.parse(der: Data([DERParser.Tag.integer.rawValue, 0x01, 0x85]))
     XCTAssert(val is ASN1Integer)
     if let int = val as? ASN1Integer {
-      XCTAssertEqual(int.swiftValue, -5)
+      XCTAssertEqual(int.value, -5)
     }
     
     let longUIntData: [UInt8] = [
@@ -89,7 +89,7 @@ final class ParseValueTests: XCTestCase {
     XCTAssert(val is ASN1Integer)
     if let int = val as? ASN1Integer {
       let referenceVal = BigInt(sign: .plus, magnitude: BigUInt(Data(longUIntData)))
-      XCTAssertEqual(referenceVal, int.swiftValue)
+      XCTAssertEqual(referenceVal, int.value)
     }
   }
   
@@ -105,19 +105,19 @@ final class ParseValueTests: XCTestCase {
     var val: ASN1Value = try DERParser.parse(der: Data([DERParser.Tag.objectIdentifier.rawValue, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01]))
     XCTAssert(val is ASN1ObjectIdentifier)
     if let objectID = val as? ASN1ObjectIdentifier {
-      XCTAssertEqual(objectID.id, "1.2.840.10045.2.1")
+      XCTAssertEqual(objectID.value, "1.2.840.10045.2.1")
     }
     
     val = try DERParser.parse(der: Data([DERParser.Tag.objectIdentifier.rawValue, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07]))
     XCTAssert(val is ASN1ObjectIdentifier)
     if let objectID = val as? ASN1ObjectIdentifier {
-      XCTAssertEqual(objectID.id, "1.2.840.10045.3.1.7")
+      XCTAssertEqual(objectID.value, "1.2.840.10045.3.1.7")
     }
     
     val = try DERParser.parse(der: Data([DERParser.Tag.objectIdentifier.rawValue, 0x09, 0x2b, 0x06, 0x01, 0x04, 0x01, 0x82, 0x37, 0x15, 0x14]))
     XCTAssert(val is ASN1ObjectIdentifier)
     if let objectID = val as? ASN1ObjectIdentifier {
-      XCTAssertEqual(objectID.id, "1.3.6.1.4.1.311.21.20")
+      XCTAssertEqual(objectID.value, "1.3.6.1.4.1.311.21.20")
     }
     
     
@@ -204,7 +204,7 @@ final class ParseValueTests: XCTestCase {
       XCTAssertEqual(sequence.values.count, 1)
       XCTAssert(sequence.values.first is ASN1Boolean)
       if let bool = sequence.values.first as? ASN1Boolean {
-        XCTAssertEqual(bool.swiftValue, true)
+        XCTAssertEqual(bool.value, true)
       }
     }
     
@@ -221,7 +221,7 @@ final class ParseValueTests: XCTestCase {
       zip(sequence.values, [false, true, false]).forEach { bool, expected in
         XCTAssert(bool is ASN1Boolean)
         if let bool = bool as? ASN1Boolean {
-          XCTAssertEqual(bool.swiftValue, expected)
+          XCTAssertEqual(bool.value, expected)
         }
       }
     }
@@ -241,7 +241,7 @@ final class ParseValueTests: XCTestCase {
       XCTAssertEqual(set.count, 1)
       XCTAssert(set.any is ASN1Boolean)
       if let bool = set.any as? ASN1Boolean {
-        XCTAssertEqual(bool.swiftValue, true)
+        XCTAssertEqual(bool.value, true)
       }
     }
     
@@ -258,11 +258,11 @@ final class ParseValueTests: XCTestCase {
       
       var falseCnt = 0
       var trueCnt = 0
-      set.all.forEach { bool in
+      set.values.forEach { bool in
         XCTAssert(bool is ASN1Boolean)
         if let bool = bool as? ASN1Boolean {
-          falseCnt += bool.swiftValue == false ? 1 : 0
-          trueCnt += bool.swiftValue == true ? 1 : 0
+          falseCnt += bool.value == false ? 1 : 0
+          trueCnt += bool.value == true ? 1 : 0
         }
       }
       XCTAssert(trueCnt == 1)


### PR DESCRIPTION
I tried ASN1Parser to parse Certificate Data using

SecCertificateCopyNormalizedIssuerSequence, (https://developer.apple.com/documentation/security/2799310-seccertificatecopynormalizedissu)
but the Library crashed.
Same for SecKeyCopyExternalRepresentation (https://developer.apple.com/documentation/security/1643698-seckeycopyexternalrepresentation/)

For the first error I added "Printable String" as DER-Type, for the second I fixed the length calculation. See added Testcase "ParseCertificateTests".

If you like it, please accept pull request.
